### PR TITLE
fix(react-ui5-webcomponents-form): ensure onChange is triggered by Input

### DIFF
--- a/packages/form/src/component/MultiSelect.tsx
+++ b/packages/form/src/component/MultiSelect.tsx
@@ -1,8 +1,9 @@
-import { MultiComboBox, MultiComboBoxItem } from "@ui5/webcomponents-react";
-import { Ui5CustomEvent } from "@ui5/webcomponents-react";
 import {
+  MultiComboBox,
   MultiComboBoxDomRef,
+  MultiComboBoxItem,
   MultiComboBoxPropTypes,
+  Ui5CustomEvent,
 } from "@ui5/webcomponents-react";
 import {
   KeyboardEvent,

--- a/packages/form/src/component/Select.tsx
+++ b/packages/form/src/component/Select.tsx
@@ -1,6 +1,10 @@
-import { ComboBox, ComboBoxItem } from "@ui5/webcomponents-react";
-import { Ui5CustomEvent } from "@ui5/webcomponents-react";
-import { ComboBoxDomRef, ComboBoxPropTypes } from "@ui5/webcomponents-react";
+import {
+  ComboBox,
+  ComboBoxDomRef,
+  ComboBoxItem,
+  ComboBoxPropTypes,
+  Ui5CustomEvent,
+} from "@ui5/webcomponents-react";
 import {
   KeyboardEvent,
   ReactElement,

--- a/packages/form/src/component/autocomplete/internal/CoreAutocomplete.tsx
+++ b/packages/form/src/component/autocomplete/internal/CoreAutocomplete.tsx
@@ -9,11 +9,19 @@ import {
   SuggestionItemPropTypes,
   Ui5CustomEvent,
 } from "@ui5/webcomponents-react";
-import { KeyboardEvent, forwardRef, useCallback, useMemo } from "react";
+import {
+  KeyboardEvent,
+  MutableRefObject,
+  forwardRef,
+  useCallback,
+  useImperativeHandle,
+  useMemo,
+  useRef,
+} from "react";
 
 import { useLatestRef } from "../../../hook/useLatestRef";
 import type { DefaultAutoCompleteOption } from "../../AutoCompleteModel";
-import { triggerSubmitOnEnter } from "../../util";
+import { triggerSubmitOnEnter, useOnChangeWorkaround } from "../../util";
 import { startsWithPerTerm } from "./filter";
 
 export type { DefaultAutoCompleteOption };
@@ -214,11 +222,17 @@ export const CoreAutocomplete = forwardRef<InputDomRef, CoreAutocompleteProps>(
       shownValue = item == null ? value : getItemLabel(item);
     }
 
+    // store input ref for internal usage
+    const inputRef = useRef<InputDomRef>() as MutableRefObject<InputDomRef>;
+    useImperativeHandle(forwardedRef, () => inputRef.current);
+    // apply workaround to fix onChange event
+    useOnChangeWorkaround(inputRef, value);
+
     return (
       <Input
         {...otherProps}
         value={shownValue}
-        ref={forwardedRef}
+        ref={inputRef}
         showSuggestions={true}
         onInput={handleInput}
         onSuggestionItemSelect={handleSuggestionItemSelect}

--- a/packages/form/src/component/number/BaseNumberInput.tsx
+++ b/packages/form/src/component/number/BaseNumberInput.tsx
@@ -9,14 +9,16 @@ import {
   ClipboardEvent,
   FC,
   KeyboardEvent,
+  MutableRefObject,
   forwardRef,
   useCallback,
+  useImperativeHandle,
   useMemo,
   useRef,
   useState,
 } from "react";
 
-import { triggerSubmitOnEnter } from "../util";
+import { triggerSubmitOnEnter, useOnChangeWorkaround } from "../util";
 import {
   getCurrencyConfig,
   getCurrencyFormatter,
@@ -469,13 +471,19 @@ export const BaseNumberInput: FC<BaseNumberInputProps> = forwardRef<
     ? currentValueRef.current || ""
     : formatForDisplay(parseValue(currentValueRef.current));
 
+  // store input ref for internal usage
+  const inputRef = useRef<InputDomRef>() as MutableRefObject<InputDomRef>;
+  useImperativeHandle(forwardedRef, () => inputRef.current);
+  // apply workaround to fix onChange event
+  useOnChangeWorkaround(inputRef, formattedValue);
+
   return (
     <Input
       {...passThrough}
       type={InputType.Text}
       inputMode={maxFractionDigits === 0 ? "numeric" : "decimal"}
       maxlength={18}
-      ref={forwardedRef}
+      ref={inputRef}
       value={formattedValue}
       valueState={msgType}
       valueStateMessage={msg}

--- a/packages/form/src/component/util.ts
+++ b/packages/form/src/component/util.ts
@@ -1,9 +1,11 @@
 import { useDebounceCallback } from "@react-hook/debounce";
+import { InputDomRef } from "@ui5/webcomponents-react";
 import {
   KeyboardEvent,
   MouseEvent,
   RefObject,
   useCallback,
+  useEffect,
   useRef,
 } from "react";
 
@@ -86,4 +88,26 @@ export const useAllowAction = (
   );
 
   return [allowActionRef, setAllowAction];
+};
+
+export const useOnChangeWorkaround = (
+  inputRef: RefObject<InputDomRef>,
+  value: string | undefined
+) => {
+  useEffect(() => {
+    if (inputRef.current == null) {
+      return;
+    }
+
+    // workaround: change event is not triggered in the following case
+    //  1. user sets value to "1234"
+    //  2. input gets updated after onChange via render prop to "1"
+    //  3. user sets value to "1234"
+    // => no change will be triggered
+    // @ts-ignore
+    if (inputRef.current._changeFiredValue !== value) {
+      // @ts-ignore
+      inputRef.current._changeFiredValue = null;
+    }
+  }, [value, inputRef]);
 };

--- a/packages/form/src/field/FormValues.stories.tsx
+++ b/packages/form/src/field/FormValues.stories.tsx
@@ -29,13 +29,12 @@ const Template: Story<
 export const Standard = Template.bind({});
 Standard.args = {
   onSubmit: async (...args) => {
+    console.log("submit", ...args);
     action("submit")(...args);
 
     const [values, actions] = args;
 
-    actions.setValues([
-      { name: "text", value: "Random value: " + new Date().getTime() },
-    ]);
+    actions.setValues([{ name: "text", value: "1" }]);
   },
   render: (values) => <div>Form Values {JSON.stringify(values)}</div>,
 };

--- a/packages/form/src/field/TextInputField.tsx
+++ b/packages/form/src/field/TextInputField.tsx
@@ -1,6 +1,6 @@
 import "../form/formSupport";
 
-import { ValueState } from "@ui5/webcomponents-react";
+import { InputDomRef, ValueState } from "@ui5/webcomponents-react";
 import { FC, forwardRef, useImperativeHandle, useMemo, useRef } from "react";
 import { useController } from "react-hook-form";
 
@@ -38,7 +38,7 @@ export const TextInputField: FC<TextInputFieldProps> = forwardRef<
   });
 
   // store input ref for intenral usage
-  const inputRef = useRef<HTMLInputElement>();
+  const inputRef = useRef<InputDomRef>();
   // forward outer ref to custom element
   useImperativeHandle(forwardedRef, () => ({
     focus() {


### PR DESCRIPTION
Fixes: Change event is not triggered in the following case
1. user sets value to "1234"
2. input gets updated after onChange via render prop to "1"
3. user sets value to "1234"

=> no change event will be triggered, but we need one to update the form state