### PR TITLE
fix: workaround for incorrect submit behavior of UI5 Web Components

### DIFF
--- a/packages/form/src/component/number/NumberModel.ts
+++ b/packages/form/src/component/number/NumberModel.ts
@@ -19,7 +19,6 @@ export interface CommonNumberInputProps
     | "showSuggestions"
     | "onSelectionChange"
     | "onChange"
-    | "onKeyUp"
   > {
   /**
    * The initial value, if any.
@@ -38,13 +37,6 @@ export interface CommonNumberInputProps
    * Fired when the value has changed and the user leaves the input field.
    */
   onValue?: (value?: number) => void;
-  /**
-   * Modified onKeyUp method, which also supplies the consumer with the parsed number value.
-   */
-  onKeyUp?: (
-    event: KeyboardEvent<InputDomRef>,
-    value: number | undefined
-  ) => void;
   /**
    * Locale to use for currency formatting style.
    * Might have been provided by NumberI18nProvider, otherwise must be set manually via this attribute.

--- a/packages/form/src/field/CurrencyInputField.tsx
+++ b/packages/form/src/field/CurrencyInputField.tsx
@@ -63,11 +63,6 @@ export const CurrencyInputField = forwardRef<
     ? getValidationErrorMessage(fieldState.error, field.value)
     : undefined;
 
-  // clear error on first change
-  const onKeyUp = useCallback(() => {
-    clearErrors(name);
-  }, [clearErrors, name]);
-
   return (
     <CurrencyInput
       {...props}
@@ -91,7 +86,6 @@ export const CurrencyInputField = forwardRef<
       aria-valuemax={
         max != null ? (typeof max === "number" ? max : max.value) : undefined
       }
-      onKeyUp={hasError(fieldState.error) ? onKeyUp : undefined}
     />
   );
 });

--- a/packages/form/src/field/NumberInputField.tsx
+++ b/packages/form/src/field/NumberInputField.tsx
@@ -61,11 +61,6 @@ export const NumberInputField = forwardRef<
     ? getValidationErrorMessage(fieldState.error, field.value)
     : undefined;
 
-  // clear error on first change
-  const onKeyUp = useCallback(() => {
-    clearErrors(name);
-  }, [clearErrors, name]);
-
   return (
     <NumberInput
       {...props}
@@ -89,7 +84,6 @@ export const NumberInputField = forwardRef<
       aria-valuemax={
         max != null ? (typeof max === "number" ? max : max.value) : undefined
       }
-      onKeyUp={hasError(fieldState.error) ? onKeyUp : undefined}
     />
   );
 });

--- a/packages/form/src/form/useFormController.tsx
+++ b/packages/form/src/form/useFormController.tsx
@@ -1,3 +1,4 @@
+import { useDebounceCallback } from "@react-hook/debounce";
 import { klona } from "klona/json";
 import * as React from "react";
 import { useCallback, useEffect, useMemo, useRef } from "react";
@@ -134,6 +135,17 @@ export function useFormController<FormValues extends {}>(
     [handleSubmit, submitHandler]
   );
 
+  // NOTE / TODO / WORKAROUND: remove the following and triggerSubmit in
+  // components when https://github.com/SAP/ui5-webcomponents/issues/10534 is resolved
+  const debouncedHandleSubmit = useDebounceCallback(submitForm, 10, false);
+  const workaroundSubmitHandler = useCallback(
+    (e?: React.BaseSyntheticEvent) => {
+      e?.preventDefault();
+      debouncedHandleSubmit(e);
+    },
+    [debouncedHandleSubmit]
+  );
+
   useEffect(() => {
     // refresh action ref if any of our methods changes
     actions.current = {
@@ -148,7 +160,7 @@ export function useFormController<FormValues extends {}>(
   return {
     context: form,
     handleReset: resetForm,
-    handleSubmit: submitForm,
+    handleSubmit: workaroundSubmitHandler,
     setErrors: setErrors,
     setValues: setValues,
     reset: resetForm,


### PR DESCRIPTION
This is just a workaround to correct the submit behavior of UI5 WC.

1. trigger submit manually
2. debounce form submit handler to ensure that users submit handler is only called once

This workaround ensures that the order of change and submit events is correct. Without this workaround, the submit event would be called before the change event...