### PR TITLE
fix: support ISO8601 date time string without fractional digits

### DIFF
--- a/packages/form/src/form/adapter/date/ISODateTimeAdapter.test.ts
+++ b/packages/form/src/form/adapter/date/ISODateTimeAdapter.test.ts
@@ -1,9 +1,18 @@
 import { ISODateTimeAdapter } from "./ISODateTimeAdapter";
 
-const values: Array<{ formattedValue: string; parsedValue: Date | null }> = [
+const values: Array<{
+  formattedValue: string;
+  alternativeFormattedValue?: string;
+  parsedValue: Date | null;
+}> = [
   {
     formattedValue: "2010-12-31T23:00:00.000Z",
     parsedValue: new Date("2010-12-31T23:00:00.000Z"),
+  },
+  {
+    formattedValue: "2010-12-31T23:00:00.000Z",
+    alternativeFormattedValue: "2010-12-31T23:00:00Z",
+    parsedValue: new Date("2010-12-31T23:00:00Z"),
   },
   {
     formattedValue: "2021-10-31",
@@ -28,17 +37,27 @@ const values: Array<{ formattedValue: string; parsedValue: Date | null }> = [
   },
 ];
 
-describe(".parse(...)", () => {
-  values.forEach(({ formattedValue, parsedValue }) => {
-    test(`parses '${formattedValue}'`, () => {
-      const date = ISODateTimeAdapter.parse(formattedValue);
+describe.only(".parse(...)", () => {
+  values.forEach(
+    ({ formattedValue, alternativeFormattedValue, parsedValue }) => {
+      test(`parses '${formattedValue}'`, () => {
+        const date = ISODateTimeAdapter.parse(formattedValue);
 
-      expect(date).toStrictEqual(parsedValue);
-    });
-  });
+        expect(date).toStrictEqual(parsedValue);
+      });
+
+      if (alternativeFormattedValue) {
+        test(`parses '${alternativeFormattedValue}'`, () => {
+          const date = ISODateTimeAdapter.parse(alternativeFormattedValue);
+
+          expect(date).toStrictEqual(parsedValue);
+        });
+      }
+    }
+  );
 });
 
-describe(".format(...)", () => {
+describe.only(".format(...)", () => {
   values
     .filter(
       (item): item is { formattedValue: string; parsedValue: Date } =>

--- a/packages/form/src/form/adapter/date/ISODateTimeAdapter.ts
+++ b/packages/form/src/form/adapter/date/ISODateTimeAdapter.ts
@@ -1,8 +1,13 @@
 import { DateAdapter } from "../type/DateAdapter";
 
+const isoStringWithoutFractionalDigits = (date: Date) => {
+  // removes fractional digits from iso string
+  return `${date.toISOString().split(".")[0]}Z`;
+};
+
 /**
  * JavaScript ISO-Date Adapter (same format as Date.prototype.toISOString())
- * Parses date strings with format `YYYY-MM-DDTHH:mm:ss.sssZ`
+ * Parses date strings with format `YYYY-MM-DDTHH:mm:ss.sssZ` or `YYYY-MM-DDTHH:mm:ssZ`
  * Everything else will be ignored
  */
 export const ISODateTimeAdapter: DateAdapter<string> = {
@@ -14,7 +19,11 @@ export const ISODateTimeAdapter: DateAdapter<string> = {
 
     // check for iso date string
     const parsedValue = new Date(value);
-    if (!isNaN(Number(parsedValue)) && parsedValue.toISOString() === value) {
+    if (
+      !isNaN(Number(parsedValue)) &&
+      (parsedValue.toISOString() === value ||
+        isoStringWithoutFractionalDigits(parsedValue) === value)
+    ) {
       return parsedValue;
     }
 


### PR DESCRIPTION
`Edm.DateTimeOffset` in OData v4 uses `YYYY-MM-DDTHH:mm:ssZ` instead of `YYYY-MM-DDTHH:mm:ss.sssZ`:
- `YYYY-MM-DDTHH:mm:ssZ` will be used to return dates on responses
- `YYYY-MM-DDTHH:mm:ssZ` or `YYYY-MM-DDTHH:mm:ss.sssZ` can be used as request values, but will be mapped to `YYYY-MM-DDTHH:mm:ssZ` on response.

Without this patch, we would ignore this valid date, although JS understands this simplified format.





